### PR TITLE
make lightdm users.conf configureable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,7 @@ vnc_server_packages:
 websockify_version: "1.0.1"
 vnc_port: 5901
 websockify_port: 7000
+
+lighdm_minimum_uid: 1000
+lighdm_hidden_users: ["nobody"]
+lighdm_hidden_shells: ["/bin/false", "/usr/sbin/nologin", "/sbin/nologin"]

--- a/files/accountservice-systemuser
+++ b/files/accountservice-systemuser
@@ -1,0 +1,2 @@
+[User]
+SystemAccount=true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,9 @@
   service:
     name: lightdm
     state: restarted
+
+- name: restart Accounts Service
+  become: true
+  service:
+    name: accounts-daemon
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
 - name: Configure and install vnc-server
   tags: [vnc]
-  include_tasks: vnc.yml
+  import_tasks: vnc.yml
+  notify: restart lightdm
 
 - name: Configure and install websockify
   tags: [websockify]
-  include_tasks: websockify.yml
+  import_tasks: websockify.yml

--- a/tasks/vnc.yml
+++ b/tasks/vnc.yml
@@ -32,6 +32,7 @@
     dest: "/var/lib/AccountsService/users/{{ item }}"
     mode: "0644"
   become: true
+  notify: restart Accounts Service
   loop: "{{ lighdm_hidden_users }}"
 
 - name: Copy securetty

--- a/tasks/vnc.yml
+++ b/tasks/vnc.yml
@@ -1,40 +1,51 @@
 ---
 - name: vnc server packages
-  apt: 
-    name: "{{ vnc_server_packages }}" 
+  apt:
+    name: "{{ vnc_server_packages }}"
     state: present
-  become: yes
-  notify: restart lightdm
+  become: true
 
 - name: configure lightdm-vnc
   template:
     src: "lightdm-vnc.conf"
     dest: "/etc/lightdm/lightdm.conf.d/vnc.conf"
     mode: "0644"
-  become: yes
-  notify: restart lightdm
+  become: true
 
 - name: configure lightdm-xdmcp
   template:
     src: "lightdm-xdmcp.conf"
     dest: "/etc/lightdm/lightdm.conf.d/xdmcp.conf"
     mode: "0644"
-  become: yes
-  notify: restart lightdm
+  become: true
+
+- name: configure lightdm users
+  template:
+    src: "lightdm-users.conf"
+    dest: "/etc/lightdm/users.conf"
+    mode: "0644"
+  become: true
+
+- name: configure Accountservice users
+  copy:
+    src: "accountservice-systemuser"
+    dest: "/var/lib/AccountsService/users/{{ item }}"
+    mode: "0644"
+  become: true
+  loop: "{{ lighdm_hidden_users }}"
 
 - name: Copy securetty
   copy:
-    remote_src: True
+    remote_src: true
     src: /usr/share/doc/util-linux/examples/securetty
     dest: /etc/securetty
-  become: yes
-  notify: restart lightdm
+    mode: 0644
+  become: true
 
 - name: Remove kwallet from pam.d/lightdm*
   lineinfile:
     path: "/etc/pam.d/{{ item }}"
     state: absent
     regexp: '^(.*)pam_kwallet(\d?).so$'
-  become: yes
-  notify: restart lightdm
-  loop: [ "lightdm", "lightdm-autologin", "lightdm-greeter" ]
+  become: true
+  loop: ["lightdm", "lightdm-autologin", "lightdm-greeter"]

--- a/tasks/websockify.yml
+++ b/tasks/websockify.yml
@@ -1,23 +1,22 @@
 ---
 - name: Download websockify
-  become: yes
+  become: true
   get_url:
     url: "https://github.com/b3n4kh/websockify-go/releases/download/{{ websockify_version }}/websockify-go"
     dest: /usr/local/bin/websockify-go
     mode: "0755"
 
 - name: configure websockify
-  become: yes
+  become: true
   template:
     src: "websockify.service"
     dest: "/etc/systemd/system/websockify.service"
     mode: "0644"
 
 - name: Start websockify service
-  become: yes
+  become: true
   systemd:
     name: websockify
-    enabled: yes
+    enabled: true
     state: started
-    daemon_reload: yes
-
+    daemon_reload: true

--- a/templates/lightdm-users.conf
+++ b/templates/lightdm-users.conf
@@ -1,0 +1,5 @@
+[UserList]
+minimum-uid={{ lighdm_minimum_uid }}
+hidden-users={% for user in lighdm_hidden_users -%} {{ user }} {% endfor %}
+
+hidden-shells={% for shell in lighdm_hidden_shells -%} {{ shell }} {% endfor %}


### PR DESCRIPTION
refactor to conform to ansible-lint

## Changes

Adds new defaults:

```
lighdm_minimum_uid: 1000
lighdm_hidden_users: ["nobody"]
lighdm_hidden_shells: ["/bin/false", "/usr/sbin/nologin", "/sbin/nologin"]
```

Unifies all booleans to [true, false] to conform with ansible-lint
